### PR TITLE
Revert "Remove invalid tags from locked desktop needles" due to https://progress.opensuse.org/issues/135143#note-9

### DIFF
--- a/openqa-desktop-gnome-auth-required-20230724.json
+++ b/openqa-desktop-gnome-auth-required-20230724.json
@@ -12,6 +12,8 @@
   "properties": [],
   "tags": [
     "ENV-VERSION-Tumbleweed",
+    "generic-desktop",
+    "openqa-desktop",
     "openqa-desktop-gnome-auth-required"
   ]
 }

--- a/openqa-desktop-locked-20200501.json
+++ b/openqa-desktop-locked-20200501.json
@@ -20,6 +20,8 @@
   "properties": [],
   "tags": [
     "ENV-VERSION-Tumbleweed",
+    "generic-desktop",
+    "openqa-desktop",
     "openqa-desktop-locked",
     "screenlock"
   ]

--- a/openqa-desktop-locked-20230327.json
+++ b/openqa-desktop-locked-20230327.json
@@ -18,6 +18,8 @@
   "properties": [],
   "tags": [
     "ENV-VERSION-Tumbleweed",
+    "generic-desktop",
+    "openqa-desktop",
     "openqa-desktop-locked",
     "screenlock"
   ]


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-needles-openQA#20