### PR TITLE
Remove generic-desktop tag from screenlock needles

### DIFF
--- a/openqa-desktop-gnome-auth-required-20230307.json
+++ b/openqa-desktop-gnome-auth-required-20230307.json
@@ -20,7 +20,6 @@
   "properties": [],
   "tags": [
     "ENV-VERSION-Tumbleweed",
-    "generic-desktop",
     "openqa-desktop",
     "openqa-desktop-gnome-auth-required",
     "screenlock"

--- a/openqa-desktop-gnome-auth-required-20230724.json
+++ b/openqa-desktop-gnome-auth-required-20230724.json
@@ -12,7 +12,6 @@
   "properties": [],
   "tags": [
     "ENV-VERSION-Tumbleweed",
-    "generic-desktop",
     "openqa-desktop",
     "openqa-desktop-gnome-auth-required"
   ]

--- a/openqa-desktop-locked-20200501.json
+++ b/openqa-desktop-locked-20200501.json
@@ -20,7 +20,6 @@
   "properties": [],
   "tags": [
     "ENV-VERSION-Tumbleweed",
-    "generic-desktop",
     "openqa-desktop",
     "openqa-desktop-locked",
     "screenlock"

--- a/openqa-desktop-locked-20230327.json
+++ b/openqa-desktop-locked-20230327.json
@@ -18,7 +18,6 @@
   "properties": [],
   "tags": [
     "ENV-VERSION-Tumbleweed",
-    "generic-desktop",
     "openqa-desktop",
     "openqa-desktop-locked",
     "screenlock"

--- a/openqa-desktop-minimalx-login-20230327.json
+++ b/openqa-desktop-minimalx-login-20230327.json
@@ -19,7 +19,6 @@
   "properties": [],
   "tags": [
     "ENV-VERSION-Tumbleweed",
-    "generic-desktop",
     "openqa-desktop",
     "openqa-desktop-login",
     "screenlock"

--- a/openqa-desktop-minimalx-login-20230529.json
+++ b/openqa-desktop-minimalx-login-20230529.json
@@ -12,7 +12,6 @@
   "properties": [],
   "tags": [
     "ENV-VERSION-SLE15SP4",
-    "generic-desktop",
     "openqa-desktop",
     "openqa-desktop-login",
     "screenlock"


### PR DESCRIPTION
Reference: https://progress.opensuse.org/issues/135143

Validation run: http://dagr.qam.suse.cz/tests/214