### PR TITLE
fix: add a click_point to openqa-scheduled-test

### DIFF
--- a/openqa-scheduled-test-20260327.json
+++ b/openqa-scheduled-test-20260327.json
@@ -12,7 +12,8 @@
       "height": 51,
       "type": "match",
       "xpos": 433,
-      "width": 156
+      "width": 156,
+      "click_point": {"xpos": -60, "ypos": 25}
     },
     {
       "type": "exclude",


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/198716